### PR TITLE
Fixing issue #16: [Bug]: Reload doesn't work when using array of contentScript entries

### DIFF
--- a/src/ExtensionReloader.ts
+++ b/src/ExtensionReloader.ts
@@ -42,7 +42,8 @@ export default class ExtensionReloaderImpl extends AbstractPluginReloader
         this._chunkVersions[name] = hash;
         return hash !== oldVersion;
       })
-      .some(({ name }) => name === background || name === contentScript);
+	  .some(({ name }) => name === background || name === contentScript ||
+	  contentScript.includes(name));
   }
 
   _registerPlugin(compiler: Compiler) {


### PR DESCRIPTION
Added a contentScript.includes(name) check to the _contentOrBgChanged function.