### PR TITLE
Always reload extension pages, ignore reloadPage

### DIFF
--- a/src/middleware/wer-middleware.raw.ts
+++ b/src/middleware/wer-middleware.raw.ts
@@ -118,7 +118,9 @@
       switch (type) {
         case SIGN_CHANGE:
           logger("Detected Changes. Reloading ...");
-          reloadPage && window.location.reload();
+          // Always reload extension pages in the foreground when they change.
+          // This option doesn't make sense otherwise
+          window.location.reload();
           break;
 
         case SIGN_LOG:


### PR DESCRIPTION
Live reloading can only work in extension pages if they are reloaded.
The `reloadPage: false` option is useful to prevent normal tabs from
being reloaded automatically when background script changes, but we
still want to preserve automatic reloading of foreground extension pages
(options, popup, etc) even when `reloadPage` is set to `false`.

Closes #57