### PR TITLE
Stop reloading after reconnect

### DIFF
--- a/src/middleware/wer-middleware.raw.ts
+++ b/src/middleware/wer-middleware.raw.ts
@@ -102,8 +102,7 @@
         ws.onerror = () => logger(`Error trying to re-connect. Reattempting in ${RECONNECT_INTERVAL / 1000}s`, "warn");
         ws.addEventListener("open", () => {
           clearInterval(intId);
-          logger("Reconnected. Reloading plugin");
-          runtime.reload();
+          logger("Reconnected.");
         });
 
       }, RECONNECT_INTERVAL);


### PR DESCRIPTION
Problem:
The server is started before webpack emits the initial changes and
built files are written to disk, causing the installed extension,
which is trying to reconnect, to reload without having files to load.
This caused an error in the extension, where it needs to be removed
and installed again.

Solution:
We stop reloading after reconnect. This shouldn't cause problems because
the server emits a reload signal after the files are initially built,
so even if there are any changes made to the code while the server was
not available, they will still be reloaded automatically.

Assumption:
Restarting the server is the only plausible scenario where connection
might be lost and changes are made to the code.

Fixes #51