### PR TITLE
Start server only after the first emit

### DIFF
--- a/src/ExtensionReloader.ts
+++ b/src/ExtensionReloader.ts
@@ -90,7 +90,6 @@ export default class ExtensionReloaderImpl extends AbstractPluginReloader
 
     this._eventAPI = new CompilerEventsFacade(compiler);
     this._injector = middlewareInjector(parsedEntries, { port, reloadPage });
-    this._triggerer = changesTriggerer(port, reloadPage);
     this._eventAPI.afterOptimizeChunkAssets((comp, chunks) => {
       comp.assets = {
         ...comp.assets,
@@ -99,6 +98,11 @@ export default class ExtensionReloaderImpl extends AbstractPluginReloader
     });
 
     this._eventAPI.afterEmit((comp, done) => {
+      // start server after first emit, so that a reconnecting extension reloads on files have been created
+      if (!this._triggerer) {
+        this._triggerer = changesTriggerer(port, reloadPage);
+      }
+
       const { contentOrBgChanged, onlyPageChanged } = this._whatChanged(
         comp.chunks,
         parsedEntries,


### PR DESCRIPTION
Problem:
The server is started before webpack emits the initial changes and
built files are written to disk, causing the installed extension,
which is trying to reconnect, to reload without having files to load.
This caused an error in the extension, where it needs to be removed
and installed again.

Solution:
We start the server after the first webpack emit event

This PR replaces https://github.com/rubenspgcavalcante/webpack-extension-reloader/pull/59

Fixes #51
 