### PR TITLE
Fixes log building

### DIFF
--- a/src/messages/Message.ts
+++ b/src/messages/Message.ts
@@ -17,10 +17,9 @@ export default class Message {
   public get(additionalData: object = {}) {
     const code = `WER-${this.getPrefix()}${this.referenceNumber}`;
     const refLink = bold(white(`${REF_URL}#${code}`));
-    return `[${code}] ${template(
-      this.message,
-      additionalData,
-    )}.\nVisit ${refLink} for complete details\n`;
+    return `[${code}] ${
+      template(this.message)(additionalData)
+    }.\nVisit ${refLink} for complete details\n`;
   }
 
   public toString() {


### PR DESCRIPTION
Lodash returns a compiled function, not a string. As a result, the previous output was:

![image](https://user-images.githubusercontent.com/1037931/77300049-b94b7300-6ced-11ea-8cfb-78fc48adad62.png)
