### PR TITLE
Upgrade webpack to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "ws": "^7.2.0"
   },
   "peerDependencies": {
-    "webpack": "^4"
+    "webpack": "^5.36.2"
   },
   "devDependencies": {
     "@babel/core": "^7.6.4",
@@ -83,7 +83,7 @@
     "autoprefixer": "^9.6.5",
     "babel-loader": "^8.0.6",
     "chai": "^4.2.0",
-    "copy-webpack-plugin": "^5.0.4",
+    "copy-webpack-plugin": "^8.1.1",
     "css-loader": "^3.2.0",
     "husky": "^3.0.9",
     "json-loader": "^0.5.7",
@@ -99,8 +99,8 @@
     "tslint": "^5.20.1",
     "tslint-config-prettier": "^1.18.0",
     "typescript": "^3.7.2",
-    "webpack": "^4.41.2",
+    "webpack": "5.36.2",
     "webpack-bundle-analyzer": "^3.6.0",
-    "webpack-cli": "^3.3.9"
+    "webpack-cli": "^4.6.0"
   }
 }

--- a/src/hot-reload/SignEmitter.ts
+++ b/src/hot-reload/SignEmitter.ts
@@ -17,7 +17,7 @@ export default class SignEmitter {
   private _safeSignChange: (
     reloadPage: boolean,
     onlyPageChanged: boolean,
-    onSuccess: () => void,
+    onSuccess: (val?: any) => void,
     onError: (err: Error) => void,
   ) => void;
   private _server: Server;

--- a/src/middleware/middleware-injector.ts
+++ b/src/middleware/middleware-injector.ts
@@ -1,3 +1,4 @@
+import { Compilation } from "webpack";
 import { ConcatSource, Source } from "webpack-sources";
 import { SourceFactory } from "../../typings";
 import middleWareSourceBuilder from "./middleware-source-builder";
@@ -17,10 +18,11 @@ const middlewareInjector: MiddlewareInjector = (
     name === extensionPage ||
     (extensionPage && extensionPage.includes(name));
 
-  return (assets, chunks) =>
-    chunks.reduce((prev, { name, files }) => {
+  return (assets, chunks: Compilation["chunks"]) =>
+    Array.from(chunks).reduce((prev, { name, files }) => {
       if (matchBgOrContentOrPage(name)) {
         files.forEach(entryPoint => {
+          console.log(`Entry point: ${entryPoint}`);
           if (/\.js$/.test(entryPoint)) {
             const finalSrc = sourceFactory(source, assets[entryPoint]);
             prev[entryPoint] = finalSrc;

--- a/src/utils/manifest.ts
+++ b/src/utils/manifest.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "fs";
 import { flatMapDeep } from "lodash";
-import { Entry, Output } from "webpack";
+import { Compiler, Entry } from "webpack";
 import {
   bgScriptEntryErrorMsg,
   bgScriptManifestRequiredMsg,
@@ -8,7 +8,7 @@ import {
 
 export function extractEntries(
   webpackEntry: Entry,
-  webpackOutput: Output = {},
+  webpackOutput: Compiler["options"]["output"] = {},
   manifestPath: string,
 ): IEntriesOption {
   const manifestJson = JSON.parse(

--- a/src/webpack/AbstractExtensionReloader.ts
+++ b/src/webpack/AbstractExtensionReloader.ts
@@ -1,7 +1,7 @@
-import { Compiler, Plugin } from "webpack";
+import { Compiler } from "webpack";
 import CompilerEventsFacade from "./CompilerEventsFacade";
 
-export default abstract class AbstractExtensionReloader implements Plugin {
+export default abstract class AbstractExtensionReloader {
   public context: any;
   protected _injector: InjectMiddleware;
   protected _triggerer: Triggerer;

--- a/src/webpack/CompilerEventsFacade.ts
+++ b/src/webpack/CompilerEventsFacade.ts
@@ -1,18 +1,20 @@
-import { Compiler } from "webpack";
+import { Compiler, Compilation } from "webpack";
 
 export default class CompilerEventsFacade {
   public static extensionName = "webpack-extension-reloader";
   private _compiler: Compiler;
   private _legacyTapable: boolean;
 
-  constructor(compiler) {
+  constructor(compiler: Compiler) {
     this._compiler = compiler;
     this._legacyTapable = !compiler.hooks;
   }
 
-  public afterOptimizeChunkAssets(call) {
+  public afterOptimizeChunkAssets(
+    call: (compilation: Compilation, chunks: Compilation["chunks"]) => void,
+  ) {
     return this._legacyTapable
-      ? this._compiler.plugin("compilation", comp =>
+      ? (this._compiler as any).plugin("compilation", comp =>
           comp.plugin("after-optimize-chunk-assets", chunks =>
             call(comp, chunks),
           ),
@@ -27,9 +29,9 @@ export default class CompilerEventsFacade {
         );
   }
 
-  public afterEmit(call) {
+  public afterEmit(call: (compilation: Compilation) => void) {
     return this._legacyTapable
-      ? this._compiler.plugin("after-emit", call)
+      ? (this._compiler as any).plugin("after-emit", call)
       : this._compiler.hooks.afterEmit.tap(
           CompilerEventsFacade.extensionName,
           call,

--- a/typings/declarations.d.ts
+++ b/typings/declarations.d.ts
@@ -12,7 +12,7 @@ declare interface IMiddlewareTemplateParams {
 
 declare type InjectMiddleware = (
   assets: Record<string, any>,
-  chunks: IWebpackChunk[],
+  chunks: Set<any>,
 ) => Record<string, any>;
 
 declare type MiddlewareInjector = (

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,14 +12,14 @@ module.exports = (env = { analyze: false }) => ({
   target: "node",
   entry: test({ tests: "./specs/index.ts" }) || {
     [packName]: "./src/index.ts",
-    [`${packName}-cli`]: "./client/index.ts"
+    [`${packName}-cli`]: "./client/index.ts",
   },
   devtool: "inline-source-map",
   output: {
     publicPath: ".",
     path: path.resolve(__dirname, "./dist"),
     filename: "[name].js",
-    libraryTarget: "umd"
+    libraryTarget: "umd",
   },
   plugins: [
     env.analyze && isProduction(new BundleAnalyzerPlugin({ sourceMap: true })),
@@ -27,51 +27,51 @@ module.exports = (env = { analyze: false }) => ({
       banner: `/// <reference path="../typings/${packName}.d.ts" />`,
       raw: true,
       entryOnly: true,
-      include: "webpack-extension-reloader"
+      include: "webpack-extension-reloader",
     }),
     new BannerPlugin({
       banner: "#!/usr/bin/env node",
       raw: true,
       entryOnly: true,
-      include: `${packName}-cli`
-    })
+      include: `${packName}-cli`,
+    }),
   ].filter(plugin => !!plugin),
   externals: [
     ...Object.keys(pack.dependencies),
     "webpack",
-    "webpack-extension-reloader"
+    "webpack-extension-reloader",
   ],
   resolve: {
     modules: [path.resolve(__dirname, "src"), "node_modules"],
     mainFiles: ["index"],
-    extensions: [".ts", ".tsx", ".js"]
+    extensions: [".ts", ".tsx", ".js"],
   },
   optimization: {
     minimize: false,
-    nodeEnv: false
+    nodeEnv: false,
   },
   module: {
     rules: [
       {
         test: /\.jsx?$/,
         exclude: /node_modules/,
-        loaders: ["babel-loader"]
+        loader: "babel-loader",
       },
       {
         test: /\.tsx?$/,
         exclude: /node_modules/,
-        loaders: ["babel-loader", "ts-loader"]
+        use: ["babel-loader", "ts-loader"],
       },
       {
         test: /\.json$/,
         exclude: /node_modules/,
-        loaders: ["json-loader"]
+        loader: "json-loader",
       },
       {
         test: /\.txt$/,
         exclude: /node_modules/,
-        loaders: ["raw-loader"]
-      }
-    ]
-  }
+        loader: "raw-loader",
+      },
+    ],
+  },
 });


### PR DESCRIPTION
I upgraded these dependencies in order to support webpack 5:

- [x] `webpack` 4 --> 5
- [x] `webpack-cli` 3 --> 4
- [x] `copy-webpack-plugin` 4 --> 8

I applied updates from breaking changes from migrating webpack 4 to webpack 5 in this pull request:

- [x] `compilation.chunks` changed from `Chunk[]` to `Set<Chunk>`
- [x] `chunk.files` changed from `string[]` to `Set<string>`
- [x] `webpack.config.js` syntax in `module.rules` to change plural `loaders` to `loader`, and `use` for multiple loaders
- [x] Updates to some typescript typings

I also changed the `middleware.raw.ts` raw source file to bind itself to window if it exists (because I was getting errors that browser stayed `null`:

![image](https://user-images.githubusercontent.com/20717348/116823224-24de5180-ab38-11eb-8c8b-579077c8e367.png)
 